### PR TITLE
input validation

### DIFF
--- a/StepperEngine/src/Stepper/Stepper.java
+++ b/StepperEngine/src/Stepper/Stepper.java
@@ -24,12 +24,20 @@ import java.util.HashSet;
 public class Stepper {
 
     HashSet<Flow> flows;
+    String exceptionString;
 
     // attempting to load from an invalid file should NOT override any data.
     public Stepper(STStepper stStepper) {
         flows = new HashSet<>();
         for(STFlow stFlow : stStepper.getSTFlows().getSTFlow()) {
-            flows.add(new Flow(stFlow));
+            try {
+                flows.add(new Flow(stFlow));
+            }
+            // input validation exception
+            catch (RuntimeException e){
+                exceptionString=e.getMessage();
+            }
+
         }
     }
 

--- a/StepperEngine/src/Steps/Step.java
+++ b/StepperEngine/src/Steps/Step.java
@@ -3,7 +3,6 @@ package Steps;
 import DataTypes.DataType;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public abstract class  Step {
@@ -76,6 +75,18 @@ public abstract class  Step {
 
     private List<DataType> getDataMembersByName(String name) {
         return getAllData().stream().filter(d -> d.getEffectiveName().equals(name)).collect(Collectors.toList());
+    }
+
+    public boolean containsDataMember(String name){
+        return !getDataMembersByName(name).isEmpty();
+    }
+
+    public boolean checkIfDataMemberIsAssigned(String name){
+        return  getDataMembersByName(name).get(0).isAssigned();
+    }
+
+    public boolean IsDataMemberIsInput(String name){
+        return  getDataMembersByName(name).get(0).isInput();
     }
 
     public List<DataType> getAllOutputs() {


### PR DESCRIPTION
added all the input validtions i can think of, the validations are executed during the flow construction, because if not doing so it have been needed to simulate the constructoin to find errors(thus reusing code).
the validations are these:

step construction:
1.check if step exists
2.check if there no two stpes with the smae final name

flow level aliasing:
1.check if dataType exists
2.check if step exists
3.check if there are no two dataType outputs with the same effective name

custom mapping:
1.source step exists
2.target step exists
3.source data exists
4.target data exists
5.if trying to assign two or more outputs to an input
6.if trying to assign a source step that is located after the target step(like a loop)
7.the source data is actually in input
8.the target data is actually an output

end construction:
1.check if there are no free inputs that are not user-friendly