### PR TITLE
Add execution api

### DIFF
--- a/StepperEngine/src/DataTypes/DataType.java
+++ b/StepperEngine/src/DataTypes/DataType.java
@@ -1,9 +1,6 @@
 package DataTypes;
 
 public abstract class DataType<T> {
-
-    // user-friendly means it can be given by the user.
-    private boolean userFriendly;
     private String name;
     private String alias;
     private String userFriendlyName;
@@ -24,8 +21,7 @@ public abstract class DataType<T> {
     private Type type;
 
 
-    public DataType(String name, String userFriendlyName, boolean userFriendly,Type type, boolean isInput) {
-        this.userFriendly = userFriendly;
+    public DataType(String name, String userFriendlyName, Type type, boolean isInput) {
         this.userFriendlyName = userFriendlyName;
         this.name = name;
         hasAlias = false;
@@ -34,8 +30,8 @@ public abstract class DataType<T> {
         this.type=type;
     }
 
-    public DataType(String name, String userFriendlyName, boolean userFriendly, T data, Type type, boolean isInput) {
-        this(name, userFriendlyName, userFriendly, type, isInput);
+    public DataType(String name, String userFriendlyName, T data, Type type, boolean isInput) {
+        this(name, userFriendlyName, type, isInput);
         this.data = data;
     }
 
@@ -67,10 +63,6 @@ public abstract class DataType<T> {
 
     public String getEffectiveName() {
         return hasAlias ? alias : name;
-    }
-
-    public boolean isUserFriendly() {
-        return userFriendly;
     }
 
     public String getName() {
@@ -117,4 +109,5 @@ public abstract class DataType<T> {
     public boolean isInput() {
         return isInput;
     }
+
 }

--- a/StepperEngine/src/DataTypes/DataType.java
+++ b/StepperEngine/src/DataTypes/DataType.java
@@ -9,10 +9,12 @@ public abstract class DataType<T> {
 
     boolean isInput;
 
-    protected T data;
+    private T data;
 
     // important for input datatype since only 1 output can be assigned to them.
     boolean isAssigned;
+
+    boolean isDataSet;    // true if the "Data" member is set (not null...);
 
     public enum Type{
         DOUBLE, FILE, LIST, MAPPING, NUMBER, RELATION, STRING
@@ -32,7 +34,7 @@ public abstract class DataType<T> {
 
     public DataType(String name, String userFriendlyName, T data, Type type, boolean isInput) {
         this(name, userFriendlyName, type, isInput);
-        this.data = data;
+        setData(data);
     }
 
     public void setMandatory(boolean mandatory) {
@@ -57,8 +59,13 @@ public abstract class DataType<T> {
         return data;
     }
 
+    public boolean isDataSet() {
+        return isDataSet;
+    }
+
     public void setData(T data) {
         this.data = data;
+        isDataSet = true;
     }
 
     public String getEffectiveName() {

--- a/StepperEngine/src/DataTypes/DoubleType.java
+++ b/StepperEngine/src/DataTypes/DoubleType.java
@@ -12,11 +12,11 @@ public class DoubleType extends DataType<Double> implements UserFriendly{
 
     @Override
     public String getPresentableString() {
-        return data.toString();
+        return getData().toString();
     }
 
     @Override
     public void setData(String dataStr) {
-        this.data = Double.parseDouble(dataStr);
+        setData(Double.parseDouble(dataStr));
     }
 }

--- a/StepperEngine/src/DataTypes/DoubleType.java
+++ b/StepperEngine/src/DataTypes/DoubleType.java
@@ -1,17 +1,22 @@
 package DataTypes;
 
-public class DoubleType extends DataType<Double> {
+public class DoubleType extends DataType<Double> implements UserFriendly{
     public DoubleType(String name, boolean isInput) {
-        super(name, name.toLowerCase().replace('_',' '), true, Type.DOUBLE, isInput);
+        super(name, name.toLowerCase().replace('_',' '), Type.DOUBLE, isInput);
     }
     public DoubleType(Double num, boolean isInput) {
-        super("Double", "Double", true, num, Type.DOUBLE, isInput);
+        super("Double", "Double", num, Type.DOUBLE, isInput);
     }
 
-    public DoubleType(Double num, String name, boolean isInput){super(name, name.toLowerCase().replace('_',' '), true, num, Type.DOUBLE, isInput);}
+    public DoubleType(Double num, String name, boolean isInput){super(name, name.toLowerCase().replace('_',' '), num, Type.DOUBLE, isInput);}
 
     @Override
     public String getPresentableString() {
         return data.toString();
+    }
+
+    @Override
+    public void setData(String dataStr) {
+        this.data = Double.parseDouble(dataStr);
     }
 }

--- a/StepperEngine/src/DataTypes/FileType.java
+++ b/StepperEngine/src/DataTypes/FileType.java
@@ -13,7 +13,7 @@ public class FileType extends DataType<File>{
 
     @Override
     public String getPresentableString() {
-        return data.getAbsolutePath();
+        return getData().getAbsolutePath();
     }
 
 }

--- a/StepperEngine/src/DataTypes/FileType.java
+++ b/StepperEngine/src/DataTypes/FileType.java
@@ -5,11 +5,11 @@ import java.io.File;
 
 public class FileType extends DataType<File>{
     public FileType(String name, boolean isInput) {
-        super(name, name.toLowerCase().replace('_',' '), false, Type.FILE, isInput);
+        super(name, name.toLowerCase().replace('_',' '), Type.FILE, isInput);
     }
-    public FileType(File file, boolean isInput){super("File", "File", false, file, Type.FILE, isInput);}
+    public FileType(File file, boolean isInput){super("File", "File", file, Type.FILE, isInput);}
 
-    public FileType(File file, String name, boolean isInput){super(name, name.toLowerCase().replace('_',' '), false, file, Type.FILE, isInput);}
+    public FileType(File file, String name, boolean isInput){super(name, name.toLowerCase().replace('_',' '), file, Type.FILE, isInput);}
 
     @Override
     public String getPresentableString() {

--- a/StepperEngine/src/DataTypes/ListType.java
+++ b/StepperEngine/src/DataTypes/ListType.java
@@ -17,11 +17,11 @@ public class ListType extends  DataType<ArrayList<DataType>>{
     @Override
     public String getPresentableString() {
         String prestableString="";
-        if(data.isEmpty())
+        if(getData().isEmpty())
             return "The list is empty";
-        for(int i=0;i<data.size();i++)
+        for(int i=0;i<getData().size();i++)
         {
-            prestableString+=(i+1)+":"+data.get(i).getPresentableString()+", ";
+            prestableString+=(i+1)+":"+getData().get(i).getPresentableString()+", ";
         }
         return prestableString.substring(0,prestableString.length()-2);
     }

--- a/StepperEngine/src/DataTypes/ListType.java
+++ b/StepperEngine/src/DataTypes/ListType.java
@@ -4,10 +4,10 @@ import java.util.ArrayList;
 
 public class ListType extends  DataType<ArrayList<DataType>>{
 
-    public ListType(String name, boolean isInput) {super(name, name.toLowerCase().replace('_',' '), false, Type.LIST, isInput);}
-    public ListType(ArrayList<DataType> list, boolean isInput){super("List", "List", false, list, Type.LIST, isInput);}
+    public ListType(String name, boolean isInput) {super(name, name.toLowerCase().replace('_',' '), Type.LIST, isInput);}
+    public ListType(ArrayList<DataType> list, boolean isInput){super("List", "List", list, Type.LIST, isInput);}
 
-    public ListType(ArrayList<DataType> list, String name, boolean isInput){super(name, name.toLowerCase().replace('_',' '), false, list, Type.LIST, isInput);}
+    public ListType(ArrayList<DataType> list, String name, boolean isInput){super(name, name.toLowerCase().replace('_',' '), list, Type.LIST, isInput);}
 
     /**
      * returns a string in the format:

--- a/StepperEngine/src/DataTypes/MappingType.java
+++ b/StepperEngine/src/DataTypes/MappingType.java
@@ -10,6 +10,6 @@ public class MappingType extends DataType<Mapping>{
     public MappingType(Mapping mapping, String name, boolean isInput){super(name, name.toLowerCase().replace('_',' '), mapping, Type.MAPPING, isInput);}
     @Override
     public String getPresentableString() {
-        return "car: "+data.getCar()+"\ncdr: "+data.getCdr();
+        return "car: "+getData().getCar()+"\ncdr: "+getData().getCdr();
     }
 }

--- a/StepperEngine/src/DataTypes/MappingType.java
+++ b/StepperEngine/src/DataTypes/MappingType.java
@@ -3,11 +3,11 @@ package DataTypes;
 public class MappingType extends DataType<Mapping>{
 
     public MappingType(String name, boolean isInput) {
-        super(name, name.toLowerCase().replace('_',' '), false, Type.MAPPING, isInput);
+        super(name, name.toLowerCase().replace('_',' '), Type.MAPPING, isInput);
     }
 
-    public MappingType(Mapping mapping, boolean isInput){super("Mapping", "Mapping", false, mapping, Type.MAPPING, isInput);}
-    public MappingType(Mapping mapping, String name, boolean isInput){super(name, name.toLowerCase().replace('_',' '), false, mapping, Type.MAPPING, isInput);}
+    public MappingType(Mapping mapping, boolean isInput){super("Mapping", "Mapping", mapping, Type.MAPPING, isInput);}
+    public MappingType(Mapping mapping, String name, boolean isInput){super(name, name.toLowerCase().replace('_',' '), mapping, Type.MAPPING, isInput);}
     @Override
     public String getPresentableString() {
         return "car: "+data.getCar()+"\ncdr: "+data.getCdr();

--- a/StepperEngine/src/DataTypes/NumberType.java
+++ b/StepperEngine/src/DataTypes/NumberType.java
@@ -15,11 +15,11 @@ public class NumberType extends DataType<Integer> implements UserFriendly{
 
     @Override
     public String getPresentableString() {
-        return data.toString();
+        return getData().toString();
     }
 
     @Override
     public void setData(String dataStr) {
-        this.data = Integer.parseInt(dataStr);
+        setData(Integer.parseInt(dataStr));
     }
 }

--- a/StepperEngine/src/DataTypes/NumberType.java
+++ b/StepperEngine/src/DataTypes/NumberType.java
@@ -1,20 +1,25 @@
 package DataTypes;
 
-public class NumberType extends DataType<Integer> {
+public class NumberType extends DataType<Integer> implements UserFriendly{
 
     public NumberType(String name, boolean isInput) {
-        super(name, name.toLowerCase().replace('_',' '), true, Type.NUMBER, isInput);
+        super(name, name.toLowerCase().replace('_',' '), Type.NUMBER, isInput);
     }
     public NumberType(Integer num, boolean isInput) {
-        super("Number", "Number", true, num, Type.NUMBER, isInput);
+        super("Number", "Number", num, Type.NUMBER, isInput);
     }
 
     public NumberType(Integer num, String name, boolean isInput) {
-        super(name, name.toLowerCase().replace('_',' '), true, num, Type.NUMBER, isInput);
+        super(name, name.toLowerCase().replace('_',' '), num, Type.NUMBER, isInput);
     }
 
     @Override
     public String getPresentableString() {
         return data.toString();
+    }
+
+    @Override
+    public void setData(String dataStr) {
+        this.data = Integer.parseInt(dataStr);
     }
 }

--- a/StepperEngine/src/DataTypes/RelationType.java
+++ b/StepperEngine/src/DataTypes/RelationType.java
@@ -3,14 +3,14 @@ package DataTypes;
 public class RelationType extends DataType<Relation> {
 
     public RelationType(String name, boolean isInput) {
-        super(name, name.toLowerCase().replace('_',' '), false, Type.RELATION, isInput);
+        super(name, name.toLowerCase().replace('_',' '), Type.RELATION, isInput);
     }
     public RelationType(Relation relation, boolean isInput) {
-        super("Relation", "Relation", false, relation, Type.RELATION, isInput);
+        super("Relation", "Relation", relation, Type.RELATION, isInput);
     }
 
     public RelationType(Relation relation, String name, boolean isInput) {
-        super(name, name.toLowerCase().replace('_',' '), false, relation, Type.RELATION, isInput);
+        super(name, name.toLowerCase().replace('_',' '), relation, Type.RELATION, isInput);
     }
 
 

--- a/StepperEngine/src/DataTypes/RelationType.java
+++ b/StepperEngine/src/DataTypes/RelationType.java
@@ -21,8 +21,8 @@ public class RelationType extends DataType<Relation> {
      */
     @Override
     public String getPresentableString() {
-        String result = data.getRows() + " rows: ";
-        String[] colNames = data.getColumnNames();
+        String result = getData().getRows() + " rows: ";
+        String[] colNames = getData().getColumnNames();
         for (String columName : colNames)
             result += columName + ", ";
         return result;

--- a/StepperEngine/src/DataTypes/StringType.java
+++ b/StepperEngine/src/DataTypes/StringType.java
@@ -10,11 +10,11 @@ public class StringType extends DataType<String> implements UserFriendly{
 
     @Override
     public String getPresentableString() {
-        return data;
+        return getData();
     }
 
     @Override
     public void setData(String dataStr) {
-        this.data = dataStr;
+        super.setData(dataStr);
     }
 }

--- a/StepperEngine/src/DataTypes/StringType.java
+++ b/StepperEngine/src/DataTypes/StringType.java
@@ -1,15 +1,20 @@
 package DataTypes;
 
-public class StringType extends DataType<String> {
+public class StringType extends DataType<String> implements UserFriendly{
 
     public StringType(String name, boolean isInput) {
-        super(name, name.toLowerCase().replace('_',' '), true, Type.STRING, isInput);
+        super(name, name.toLowerCase().replace('_',' '), Type.STRING, isInput);
     }
 
-    public StringType(String str, String name, boolean isInput) {super(name, name.toLowerCase().replace('_',' '), true, str, Type.STRING, isInput);}
+    public StringType(String str, String name, boolean isInput) {super(name, name.toLowerCase().replace('_',' '), str, Type.STRING, isInput);}
 
     @Override
     public String getPresentableString() {
         return data;
+    }
+
+    @Override
+    public void setData(String dataStr) {
+        this.data = dataStr;
     }
 }

--- a/StepperEngine/src/DataTypes/UserFriendly.java
+++ b/StepperEngine/src/DataTypes/UserFriendly.java
@@ -1,0 +1,5 @@
+package DataTypes;
+
+public interface UserFriendly {
+    public abstract void setData(String dataStr);
+}

--- a/StepperEngine/src/Flow/FlowDescriptor.java
+++ b/StepperEngine/src/Flow/FlowDescriptor.java
@@ -1,0 +1,72 @@
+package Flow;
+
+import Steps.StepDescriptor;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+
+public class FlowDescriptor {
+    private String flowName;
+    private String flowDescription;
+    private HashSet<String> formalOutputNames; //maybe not needed? can be extracted from "outputs" member
+    private boolean isReadonly;
+    private ArrayList<StepDescriptor> stepDescriptors;
+    private ArrayList<FreeInputDescriptor> freeInputs;
+    private ArrayList<StepOutputDescriptor> outputs;
+
+    public String getFlowName() {
+        return flowName;
+    }
+
+    public void setFlowName(String flowName) {
+        this.flowName = flowName;
+    }
+
+    public String getFlowDescription() {
+        return flowDescription;
+    }
+
+    public void setFlowDescription(String flowDescription) {
+        this.flowDescription = flowDescription;
+    }
+
+    public HashSet<String> getFormalOutputNames() {
+        return formalOutputNames;
+    }
+
+    public void setFormalOutputNames(HashSet<String> formalOutputNames) {
+        this.formalOutputNames = formalOutputNames;
+    }
+
+    public boolean isReadonly() {
+        return isReadonly;
+    }
+
+    public void setReadonly(boolean readonly) {
+        isReadonly = readonly;
+    }
+
+    public ArrayList<StepDescriptor> getStepDescriptors() {
+        return stepDescriptors;
+    }
+
+    public void setStepDescriptors(ArrayList<StepDescriptor> stepDescriptors) {
+        this.stepDescriptors = stepDescriptors;
+    }
+
+    public ArrayList<FreeInputDescriptor> getFreeInputs() {
+        return freeInputs;
+    }
+
+    public void setFreeInputs(ArrayList<FreeInputDescriptor> freeInputs) {
+        this.freeInputs = freeInputs;
+    }
+
+    public ArrayList<StepOutputDescriptor> getOutputs() {
+        return outputs;
+    }
+
+    public void setOutputs(ArrayList<StepOutputDescriptor> outputs) {
+        this.outputs = outputs;
+    }
+}

--- a/StepperEngine/src/Flow/FreeInputDescriptor.java
+++ b/StepperEngine/src/Flow/FreeInputDescriptor.java
@@ -1,0 +1,51 @@
+package Flow;
+
+import DataTypes.DataType;
+
+import java.util.ArrayList;
+
+public class FreeInputDescriptor {
+    private String inputEffectiveName;
+    private DataType.Type inputType;
+    private ArrayList<String> associatedSteps; //These are the EFFECTIVE names of the steps
+    private boolean isMandatory;
+
+    public FreeInputDescriptor(String inputEffectiveName, DataType.Type inputType, boolean isMandatory) {
+        this.inputEffectiveName = inputEffectiveName;
+        this.inputType = inputType;
+        this.associatedSteps = new ArrayList<>();
+        this.isMandatory = isMandatory;
+    }
+
+    public String getInputEffectiveName() {
+        return inputEffectiveName;
+    }
+
+    public void setInputEffectiveName(String inputEffectiveName) {
+        this.inputEffectiveName = inputEffectiveName;
+    }
+
+    public DataType.Type getInputType() {
+        return inputType;
+    }
+
+    public void setInputType(DataType.Type inputType) {
+        this.inputType = inputType;
+    }
+
+    public ArrayList<String> getAssociatedSteps() {
+        return associatedSteps;
+    }
+
+    public void setAssociatedSteps(ArrayList<String> associatedSteps) {
+        this.associatedSteps = associatedSteps;
+    }
+
+    public boolean isMandatory() {
+        return isMandatory;
+    }
+
+    public void setMandatory(boolean mandatory) {
+        isMandatory = mandatory;
+    }
+}

--- a/StepperEngine/src/Flow/FreeInputDescriptor.java
+++ b/StepperEngine/src/Flow/FreeInputDescriptor.java
@@ -6,11 +6,14 @@ import java.util.ArrayList;
 
 public class FreeInputDescriptor {
     private String inputEffectiveName;
+
+    private String inputUserFriendlyName;
     private DataType.Type inputType;
     private ArrayList<String> associatedSteps; //These are the EFFECTIVE names of the steps
     private boolean isMandatory;
 
-    public FreeInputDescriptor(String inputEffectiveName, DataType.Type inputType, boolean isMandatory) {
+    public FreeInputDescriptor(String inputEffectiveName, String inputUserFriendlyName, DataType.Type inputType, boolean isMandatory) {
+        this.inputUserFriendlyName = inputUserFriendlyName;
         this.inputEffectiveName = inputEffectiveName;
         this.inputType = inputType;
         this.associatedSteps = new ArrayList<>();

--- a/StepperEngine/src/Flow/StepOutputDescriptor.java
+++ b/StepperEngine/src/Flow/StepOutputDescriptor.java
@@ -1,0 +1,42 @@
+package Flow;
+
+import DataTypes.DataType;
+
+import java.util.ArrayList;
+
+public class StepOutputDescriptor {
+    private String outputEffectiveName;
+    private DataType.Type outputType;
+    private String sourceStepName; // these are the EFFECTIVE names.
+
+    public StepOutputDescriptor(String outputEffectiveName, DataType.Type outputType, String sourceStepName) {
+        this.outputEffectiveName = outputEffectiveName;
+        this.outputType = outputType;
+        this.sourceStepName = sourceStepName;
+    }
+
+    public String getOutputEffectiveName() {
+        return outputEffectiveName;
+    }
+
+    public void setOutputEffectiveName(String outputEffectiveName) {
+        this.outputEffectiveName = outputEffectiveName;
+    }
+
+    public DataType.Type getOutputType() {
+        return outputType;
+    }
+
+    public void setOutputType(DataType.Type outputType) {
+        this.outputType = outputType;
+    }
+
+    public String getSourceStepName() {
+        return sourceStepName;
+    }
+
+    public void setSourceStepName(String sourceStepsNames) {
+        this.sourceStepName = sourceStepsNames;
+    }
+}
+

--- a/StepperEngine/src/Main.java
+++ b/StepperEngine/src/Main.java
@@ -2,7 +2,9 @@
 import DataTypes.*;
 
 import Flow.Flow;
+import Flow.FlowDescriptor;
 import Generated.STStepper;
+import Stepper.StepperUIManager;
 import Steps.*;
 
 import javax.xml.bind.JAXBContext;
@@ -14,16 +16,13 @@ import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.HashMap;
 
+
 public class Main {
     public static void main(String[] args) throws FileNotFoundException, JAXBException {
-//        Step step = new StepFactory().createStep("Collect Files In Folder");
-
-//        System.out.println(step.getName());
-//
-
-        String xmlPath = "C:\\Users\\Ofir\\Downloads\\ex1.xml";
-        STStepper stepper = deserializeFrom(new FileInputStream(new File(xmlPath)));
-        Flow flow = new Flow(stepper.getSTFlows().getSTFlow().get(0));
+        StepperUIManager uiManager = new StepperUIManager();
+        uiManager.LoadStepperFromXmlFile("C:\\Users\\Ofir\\Downloads\\ex1(8).xml");
+        System.out.println(uiManager.getFlowNames());
+        FlowDescriptor flowDescriptor = uiManager.getFlowDescriptor("Rename Files");
     }
 
     private static STStepper deserializeFrom(FileInputStream in) throws JAXBException {

--- a/StepperEngine/src/Main.java
+++ b/StepperEngine/src/Main.java
@@ -1,8 +1,7 @@
 
 import DataTypes.*;
 
-import Flow.Flow;
-import Flow.FlowDescriptor;
+import Flow.*;
 import Generated.STStepper;
 import Stepper.StepperUIManager;
 import Steps.*;
@@ -19,11 +18,32 @@ import java.util.HashMap;
 
 public class Main {
     public static void main(String[] args) throws FileNotFoundException, JAXBException {
+        testFlowExecution();
+
+
+    }
+
+    public static void testFlowExecution() throws FileNotFoundException, JAXBException
+    {
         StepperUIManager uiManager = new StepperUIManager();
         uiManager.LoadStepperFromXmlFile("C:\\Users\\Ofir\\Downloads\\ex1(8).xml");
         System.out.println(uiManager.getFlowNames());
         FlowDescriptor flowDescriptor = uiManager.getFlowDescriptor("Rename Files");
+
+        ArrayList<FreeInputDescriptor> freeInputDescriptors = uiManager.getFreeInputDescriptorsByFlow("Rename Files");
+
+
+        uiManager.setFreeInput("Rename Files", "FOLDER_NAME", "C:\\temp");
+        uiManager.setFreeInput("Rename Files", "PREFIX", "123");
+        uiManager.setFreeInput("Rename Files", "CSV_FILE_NAME", "C:\\temp\\dump.csv");
+        uiManager.setFreeInput("Rename Files", "PROP_FILE_NAME", "C:\\temp\\propdump.csv");
+
+
+        uiManager.runFlow("Rename Files");
+
+
     }
+
 
     private static STStepper deserializeFrom(FileInputStream in) throws JAXBException {
         JAXBContext jc = JAXBContext.newInstance("Generated");
@@ -31,19 +51,19 @@ public class Main {
         return (STStepper) u.unmarshal(in);
     }
 
-    public static void flowTest() throws FileNotFoundException, JAXBException {
-        String xmlPath = "C:\\Users\\igal6\\Downloads\\ex1.xml";
-        STStepper stepper = deserializeFrom(new FileInputStream(new File(xmlPath)));
-        Flow flow = new Flow(stepper.getSTFlows().getSTFlow().get(1));
-        ArrayList<DataType> arr=new ArrayList<>();
-        DataType<Integer> number=new NumberType(3,"TIME_TO_SPEND",true);
-        DataType<String> filter=new StringType(".txt","FILTER",true);
-        DataType<String> folder=new StringType("C:\\Users\\igal6\\Downloads\\folder test","FOLDER_NAME",true);
-        arr.add(number);
-        arr.add(filter);
-        arr.add(folder);
-        flow.execution(arr);
-    }
+//    public static void flowTest() throws FileNotFoundException, JAXBException {
+//        String xmlPath = "C:\\Users\\igal6\\Downloads\\ex1.xml";
+//        STStepper stepper = deserializeFrom(new FileInputStream(new File(xmlPath)));
+//        Flow flow = new Flow(stepper.getSTFlows().getSTFlow().get(1));
+//        ArrayList<DataType> arr=new ArrayList<>();
+//        DataType<Integer> number=new NumberType(3,"TIME_TO_SPEND",true);
+//        DataType<String> filter=new StringType(".txt","FILTER",true);
+//        DataType<String> folder=new StringType("C:\\Users\\igal6\\Downloads\\folder test","FOLDER_NAME",true);
+//        arr.add(number);
+//        arr.add(filter);
+//        arr.add(folder);
+//        flow.execution(arr);
+//    }
 
     public static void csvExporterTest() {
 //        Relation table = new Relation(3,3, "First Name", "Family Name", "Age");

--- a/StepperEngine/src/Stepper/Stepper.java
+++ b/StepperEngine/src/Stepper/Stepper.java
@@ -10,8 +10,7 @@ Things To Consider:
  */
 
 
-import Flow.Flow;
-import Flow.FlowDescriptor;
+import Flow.*;
 import Generated.STFlow;
 import Generated.STStepper;
 
@@ -69,5 +68,21 @@ public class Stepper {
         for(Flow flow : flows)
             flowNames.add(flow.getName());
         return flowNames;
+    }
+
+    public ArrayList<FreeInputDescriptor> getFreeInputDescriptorsByFlow(String flowName) {
+        return getFlowByName(flowName).getFreeInputsDescriptors();
+    }
+
+    public void setFreeInput(String flowName, String freeInputEffectiveName, String dataStr) {
+        getFlowByName(flowName).setFreeInput(freeInputEffectiveName, dataStr);
+    }
+
+    public boolean areAllMandatoryFreeInputsSet(String flowName) {
+        return getFlowByName(flowName).areAllMandatoryFreeInputsSet();
+    }
+
+    public void runFlow(String flowName) {
+        getFlowByName(flowName).execute();
     }
 }

--- a/StepperEngine/src/Stepper/Stepper.java
+++ b/StepperEngine/src/Stepper/Stepper.java
@@ -11,6 +11,7 @@ Things To Consider:
 
 
 import Flow.Flow;
+import Flow.FlowDescriptor;
 import Generated.STFlow;
 import Generated.STStepper;
 
@@ -19,6 +20,8 @@ import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
 import java.util.HashSet;
 
 public class Stepper {
@@ -26,8 +29,10 @@ public class Stepper {
     HashSet<Flow> flows;
     String exceptionString;
 
+
     // attempting to load from an invalid file should NOT override any data.
-    public Stepper(STStepper stStepper) {
+    public Stepper(String xmlFilePath) throws FileNotFoundException, JAXBException{
+        STStepper stStepper = deserializeFrom(new FileInputStream(new File(xmlFilePath)));
         flows = new HashSet<>();
         for(STFlow stFlow : stStepper.getSTFlows().getSTFlow()) {
             try {
@@ -36,9 +41,33 @@ public class Stepper {
             // input validation exception
             catch (RuntimeException e){
                 exceptionString=e.getMessage();
+                throw e;
             }
-
         }
     }
 
+    public FlowDescriptor getFlowDescriptor(String flowName) {
+        return getFlowByName(flowName).getFlowDescriptor();
+    }
+
+    private Flow getFlowByName(String flowName) {
+        for(Flow flow : flows) {
+            if(flow.getName().equals(flowName))
+                return flow;
+        }
+        throw new RuntimeException("getFlowByName: flow '" + flowName + " not found");
+    }
+
+    private STStepper deserializeFrom(FileInputStream in) throws JAXBException {
+        JAXBContext jc = JAXBContext.newInstance("Generated");
+        Unmarshaller u = jc.createUnmarshaller();
+        return (STStepper) u.unmarshal(in);
+    }
+
+    public ArrayList<String> getFlowNames(){
+        ArrayList<String> flowNames = new ArrayList<>();
+        for(Flow flow : flows)
+            flowNames.add(flow.getName());
+        return flowNames;
+    }
 }

--- a/StepperEngine/src/Stepper/StepperUIManager.java
+++ b/StepperEngine/src/Stepper/StepperUIManager.java
@@ -3,8 +3,7 @@ package Stepper;
 // This object acts as a Facade, offering the Stepper system UI functions
 // and managing the stepper object itself
 
-import Flow.Flow;
-import Flow.FlowDescriptor;
+import Flow.*;
 import Generated.STStepper;
 
 import javax.xml.bind.JAXBException;
@@ -35,5 +34,20 @@ public class StepperUIManager {
         return stepper.getFlowDescriptor(flowName);
     }
 
+    public ArrayList<FreeInputDescriptor> getFreeInputDescriptorsByFlow(String flowName) {
+        return stepper.getFreeInputDescriptorsByFlow(flowName);
+    }
+
+    public void setFreeInput(String flowName, String freeInputEffectiveName, String dataStr) {
+        stepper.setFreeInput(flowName, freeInputEffectiveName, dataStr);
+    }
+
+    public boolean areAllMandatoryFreeInputsSet(String flowName) {
+        return stepper.areAllMandatoryFreeInputsSet(flowName);
+    }
+
+    public void runFlow(String flowName) {
+        stepper.runFlow(flowName);
+    }
 
 }

--- a/StepperEngine/src/Stepper/StepperUIManager.java
+++ b/StepperEngine/src/Stepper/StepperUIManager.java
@@ -4,29 +4,36 @@ package Stepper;
 // and managing the stepper object itself
 
 import Flow.Flow;
+import Flow.FlowDescriptor;
+import Generated.STStepper;
 
+import javax.xml.bind.JAXBException;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.HashSet;
 
 public class StepperUIManager {
     Stepper stepper;
     boolean isLoaded;
-    HashSet<Flow> flows;
 
     public StepperUIManager() {
         isLoaded = false;
     }
 
-    public void LoadStepperFromXmlFile(File xmlFile) {
-
-        // don't forget to set isLoaded
+    public void LoadStepperFromXmlFile(String xmlFilePath) throws FileNotFoundException, JAXBException {
+        stepper = new Stepper(xmlFilePath);
+        isLoaded = true;
     }
 
     public ArrayList<String> getFlowNames(){
-        ArrayList<String> flowNames = new ArrayList<>();
-        for(Flow flow : flows)
-            flowNames.add(flow.getName());
-        return flowNames;
+        return stepper.getFlowNames();
     }
+
+    public FlowDescriptor getFlowDescriptor(String flowName) {
+        return stepper.getFlowDescriptor(flowName);
+    }
+
+
 }

--- a/StepperEngine/src/Steps/CollectFilesInFolderStep.java
+++ b/StepperEngine/src/Steps/CollectFilesInFolderStep.java
@@ -23,6 +23,7 @@ public class CollectFilesInFolderStep extends Step{
         this(folderName);
         this.filter = filter;
         this.filter.setMandatory(false);
+        this.folderName.setMandatory(true);
     }
 
     public CollectFilesInFolderStep(){
@@ -31,6 +32,7 @@ public class CollectFilesInFolderStep extends Step{
         this.totalFound=new NumberType(new Integer(0),StepOutputNameEnum.TOTAL_FOUND.toString(), false);
         this.folderName = new StringType(StepInputNameEnum.FOLDER_NAME.toString(), true);
         this.filter = new StringType(StepInputNameEnum.FILTER.toString(), true);
+        this.folderName.setMandatory(true);
     }
 
     @Override

--- a/StepperEngine/src/Steps/CsvExporterStep.java
+++ b/StepperEngine/src/Steps/CsvExporterStep.java
@@ -17,6 +17,7 @@ public class CsvExporterStep extends Step {
         super("CSV Exporter", true);
         this.result=new StringType(new String(), StepOutputNameEnum.RESULT.toString(), false);
         this.source = new RelationType(StepInputNameEnum.SOURCE.toString(), true);
+        this.source.setMandatory(true);
     }
 
     public CsvExporterStep(RelationType source) {

--- a/StepperEngine/src/Steps/FileDumperStep.java
+++ b/StepperEngine/src/Steps/FileDumperStep.java
@@ -18,6 +18,8 @@ public class FileDumperStep extends  Step{
         this.result=new StringType(new String(), StepOutputNameEnum.RESULT.toString(), false);
         this.content = new StringType(StepInputNameEnum.CONTENT.toString(), true);
         this.fileName = new StringType(StepInputNameEnum.FILE_NAME.toString(), true);
+        this.content.setMandatory(true);
+        this.fileName.setMandatory(true);
     }
 
     public FileDumperStep(StringType content, StringType fileName){

--- a/StepperEngine/src/Steps/FilesContentExtractorStep.java
+++ b/StepperEngine/src/Steps/FilesContentExtractorStep.java
@@ -16,6 +16,8 @@ public class FilesContentExtractorStep extends Step {
 
         this.filesList = new ListType(StepInputNameEnum.FILES_LIST.toString(), true);
         this.lineNumber = new NumberType(StepInputNameEnum.LINE.toString(), true);
+        this.filesList.setMandatory(true);
+        this.lineNumber.setMandatory(true);
     }
 
     public FilesContentExtractorStep(ListType filesList, NumberType lineNumber) {

--- a/StepperEngine/src/Steps/FilesDeleterStep.java
+++ b/StepperEngine/src/Steps/FilesDeleterStep.java
@@ -22,6 +22,7 @@ public class FilesDeleterStep extends Step{
         this.deletionStats=new MappingType(new Mapping(), StepOutputNameEnum.DELETION_STATS.toString(), false);
 
         this.filesList = new ListType(StepInputNameEnum.FILES_LIST.toString(), true);
+        this.filesList.setMandatory(true);
     }
     @Override
     public void execute() {

--- a/StepperEngine/src/Steps/FilesRenamerStep.java
+++ b/StepperEngine/src/Steps/FilesRenamerStep.java
@@ -28,6 +28,7 @@ public class FilesRenamerStep extends Step {
         this.renameResult=new RelationType(new Relation(1,1,"something to fill"), StepOutputNameEnum.RENAME_RESULT.toString(), false);
 
         this.filesToRename = new ListType(StepInputNameEnum.FILES_TO_RENAME.toString(), true);
+        this.filesToRename.setMandatory(true);
         this.prefix = new StringType(StepInputNameEnum.PREFIX.toString(), true);
         this.suffix = new StringType(StepInputNameEnum.SUFFIX.toString(), true);
     }

--- a/StepperEngine/src/Steps/PropertiesExporterStep.java
+++ b/StepperEngine/src/Steps/PropertiesExporterStep.java
@@ -13,6 +13,7 @@ public class PropertiesExporterStep extends Step{
         this.result=new StringType(new String(), StepOutputNameEnum.RESULT.toString(), false);
 
         this.source = new RelationType(StepInputNameEnum.SOURCE.toString(), true);
+        this.source.setMandatory(true);
     }
 
     public PropertiesExporterStep(RelationType source) {

--- a/StepperEngine/src/Steps/SpendSomeTimeStep.java
+++ b/StepperEngine/src/Steps/SpendSomeTimeStep.java
@@ -15,13 +15,13 @@ public class SpendSomeTimeStep extends Step{
         super("Spend Some Time", true);
 
         this.secondsToSpend = new NumberType(StepInputNameEnum.TIME_TO_SPEND.toString(), true);
+        secondsToSpend.setMandatory(true);
     }
 
     public SpendSomeTimeStep(NumberType secondsToSpend) {
         this();
         this.secondsToSpend = secondsToSpend;
         this.secondsToSpend.setMandatory(true);
-
     }
 
     @Override

--- a/StepperEngine/src/Steps/Step.java
+++ b/StepperEngine/src/Steps/Step.java
@@ -167,4 +167,8 @@ public abstract class  Step {
     public void setBlocking(boolean blocking) {
         isBlocking = blocking;
     }
+
+    public StepDescriptor getStepDescriptor() {
+        return new StepDescriptor(name, alias, hasAlias, isReadOnly);
+    }
 }

--- a/StepperEngine/src/Steps/Step.java
+++ b/StepperEngine/src/Steps/Step.java
@@ -35,6 +35,7 @@ public abstract class  Step {
         this.hasAlias=false;
         this.status=Status.NotRunYet;
         outputs = new ArrayList<DataType>();
+        isBlocking = true;
     }
 
     public abstract void execute();

--- a/StepperEngine/src/Steps/StepDescriptor.java
+++ b/StepperEngine/src/Steps/StepDescriptor.java
@@ -1,0 +1,47 @@
+package Steps;
+
+public class StepDescriptor {
+    private String stepName;
+    private String stepAlias;
+    private boolean hasAlias;
+    private boolean isReadOnly;
+
+    public StepDescriptor(String stepName, String stepAlias, boolean hasAlias, boolean isReadOnly) {
+        this.stepName = stepName;
+        this.stepAlias = stepAlias;
+        this.hasAlias = hasAlias;
+        this.isReadOnly = isReadOnly;
+    }
+
+    public String getStepName() {
+        return stepName;
+    }
+
+    public void setStepName(String stepName) {
+        this.stepName = stepName;
+    }
+
+    public String getStepAlias() {
+        return stepAlias;
+    }
+
+    public void setStepAlias(String stepAlias) {
+        this.stepAlias = stepAlias;
+    }
+
+    public boolean isHasAlias() {
+        return hasAlias;
+    }
+
+    public void setHasAlias(boolean hasAlias) {
+        this.hasAlias = hasAlias;
+    }
+
+    public boolean isReadOnly() {
+        return isReadOnly;
+    }
+
+    public void setReadOnly(boolean readOnly) {
+        isReadOnly = readOnly;
+    }
+}


### PR DESCRIPTION
Removed the "**isUserFriendly**" field from DataType, and implemented an interface "**UserFriendly**" instead, which has one abstract method "**setData(String)**" that parses a string into the data.

The reason for this is that I couldn't find a good way to implement the "enter free inputs" UI mechanism otherwise.  I needed a way to parse just the user friendly fields from strings, and not the other ones. 

Also, I removed to input parameters from the execution (now called **execute**) method. Instead, **execute** gets no parameters, and it expects all of the free mandatory inputs to be **already set** by the time it's called, and if not it throws an exception.

And, **StepperUIManager** gives an easy API for the user to enter (an re-enter as much as he wants) all the free inputs before calling execute. (**setFreeInput**(String flowName, String freeInputEffectiveName, String dataStr))

also, I set "**isBlocking**" to be **true** by default.

And added an "**isDataSet**" field that helps checking if all free inputs are set before executing the flow.




